### PR TITLE
Introducing version.py and using it in setup.py to get the python

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include RELEASE-VERSION
+include version.py
 include README.md
 include run_tests.sh
 include settings.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+
+clean:
+	rm -rf build dist src/*.egg-info/
+
+.PHONY : build
+build: clean
+	python setup.py build
+
+build_eggs: build
+	python setup.py bdist_egg
+
+build_packages: build_eggs
+	python setup.py bdist_rpm
+
+install: build
+	python setup.py clean --all
+	python setup.py install
+
+test:
+	python runtests.py src
+
+register:
+	python setup.py sdist bdist_egg upload -r pypi
+
+check:
+	pylint -i y --output-format=parseable src/`git remote -v | grep origin | head -1 | cut -d':' -f 2 | cut -d'.' -f 1`
+

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from distutils.cmd import Command
 
-__version__ = "1.5.0-SNAPSHOT"
+import version
 
 long_description = """pyaccumulo is a python client library for Apache Accumulo that uses the Accumulo Thrift Proxy"""
 
@@ -98,7 +98,7 @@ Please ask in the user forums for help.
 
 setup(
       name = 'pyaccumulo',
-      version = __version__,
+      version = version.get_git_version(),
       author = 'Jason Trost',
       author_email = 'jason.trost AT gmail.com',
       maintainer = 'Jason Trost',

--- a/version.py
+++ b/version.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# Author: Douglas Creager <dcreager@dcreager.net>
+# This file is placed into the public domain.
+ 
+# Calculates the current version number.  If possible, this is the
+# output of “git describe”, modified to conform to the versioning
+# scheme that setuptools uses.  If “git describe” returns an error
+# (most likely because we're in an unpacked copy of a release tarball,
+# rather than in a git working copy), then we fall back on reading the
+# contents of the RELEASE-VERSION file.
+#
+# To use this script, simply import it your setup.py file, and use the
+# results of get_git_version() as your package version:
+#
+# from version import *
+#
+# setup(
+#     version=get_git_version(),
+#     .
+#     .
+#     .
+# )
+#
+# This will automatically update the RELEASE-VERSION file, if
+# necessary.  Note that the RELEASE-VERSION file should *not* be
+# checked into git; please add it to your top-level .gitignore file.
+#
+# You'll probably want to distribute the RELEASE-VERSION file in your
+# sdist tarballs; to do this, just create a MANIFEST.in file that
+# contains the following line:
+#
+#   include RELEASE-VERSION
+ 
+__all__ = ("get_git_version")
+ 
+from subprocess import Popen, PIPE
+ 
+ 
+def call_git_describe(abbrev=4):
+    try:
+        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+                  stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        return line.strip()
+ 
+    except:
+        return None
+ 
+ 
+def read_release_version():
+    try:
+        f = open("RELEASE-VERSION", "r")
+ 
+        try:
+            version = f.readlines()[0]
+            return version.strip()
+ 
+        finally:
+            f.close()
+ 
+    except:
+        return None
+ 
+ 
+def write_release_version(version):
+    f = open("RELEASE-VERSION", "w")
+    f.write("%s\n" % version)
+    f.close()
+ 
+ 
+def get_git_version(abbrev=4):
+    # Read in the version that's currently in RELEASE-VERSION.
+ 
+    release_version = read_release_version()
+ 
+    # First try to get the current version using “git describe”.
+ 
+    version = call_git_describe(abbrev)
+ 
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+ 
+    if version is None:
+        version = release_version
+ 
+    # If we still don't have anything, that's an error.
+ 
+    if version is None:
+        # raise ValueError("Cannot find the version number!")
+        version = '0.1.0'
+ 
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+ 
+    if version != release_version:
+        write_release_version(version)
+ 
+    # Finally, return the current version.
+ 
+    return version
+ 
+ 
+if __name__ == "__main__":
+    print get_git_version()


### PR DESCRIPTION
package version number from `git describe`, so we can have officially
tagged versions, and releases distinguished by commit hash.

Also introducing Makefile, which helps regiment some of these setup.py
commands, and will facilitate auto testing.

I have tested this with pypi by creating:

https://pypi.python.org/pypi?%3Aaction=pkg_edit&name=pyaccumulo-dev

and verifying that this works in a setup.py of a project depending on this package:

```
install_requires=[
    'pyaccumulo_dev >= 1.5.0-SNAPSHOT.1',
],
```

Problem:  a pull request like this does not transmit tags.  This scheme still works even without tags agreeing across forks, because it constructs release number and uses git hash.  This schemes works better if we coordinate tags by designing a release process that tags versions of this python package with tags like 1.5.0-SNAPSHOT.1   etc.
